### PR TITLE
Refactor implementation that forced iterator to memory reading

### DIFF
--- a/src/IteratorWrapper.php
+++ b/src/IteratorWrapper.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Maatwebsite\ExcelLight;
+
+use Iterator;
+
+class IteratorWrapper implements Iterator
+{
+  
+    public function __construct(IteratorAggregate $iterator, $classBuilderCallback)
+    {
+        $this->iterator = $iterator;
+        $this->classBuilderCallback = $classBuilderCallback;
+    }
+  
+    public function current()
+    {
+        return $this->classBuilderCallback($this->iterator->current());
+    }
+
+    public function key()
+    {
+        return $this->iterator->key();
+    }
+
+    public function next()
+    {
+        return $this->iterator->next();
+    }
+
+    public function rewind()
+    {
+        return $this->iterator->rewind();
+    }
+
+    public function valid()
+    {
+        return $this->iterator->valid();
+    }
+    
+}

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -47,21 +47,17 @@ class Reader implements IteratorAggregate
      */
     public function sheets(callable $callback = null)
     {
-        $sheets = new Collection(
-            iterator_to_array($this->reader->getSheetIterator())
-        );
-
-        $sheets = $sheets->map(function (SheetInterface $sheet) {
-            return new Sheet($sheet);
-        });
-
         if (is_callable($callback)) {
-            foreach ($sheets as $sheet) {
+            $iterator = new IteratorWrapper($this->getIterator(), function($sheet) use ($callback) {
                 $callback($sheet);
-            }
+                return $sheet;
+            });
+            
+            foreach($iterator as $sheet) { /* DON'T CARE! :) */ }
+            return $iterator;
+        } else {
+            return $this->getIterator();
         }
-
-        return $sheets;
     }
 
     /**
@@ -74,6 +70,14 @@ class Reader implements IteratorAggregate
     public function getIterator()
     {
         return $this->sheets();
+    }
+    
+    public function getIterator()
+    {
+        $sheetIterator = $this->sheet->getSheetIterator();
+        return new IteratorWrapper($sheetIterator, function ($sheet) {
+            new Sheet($sheet)
+        });
     }
 
     /**

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -53,7 +53,7 @@ class Reader implements IteratorAggregate
                 return $sheet;
             });
             
-            foreach($iterator as $sheet) { /* DON'T CARE! :) */ }
+            foreach($iterator as $sheet) { /* Just force iterating */ }
             return $iterator;
         } else {
             return $this->getIterator();

--- a/src/Sheet.php
+++ b/src/Sheet.php
@@ -54,7 +54,7 @@ class Sheet implements IteratorAggregate
                 return $row;
             });
             
-            foreach($iterator as $row) { /* DON'T CARE! :) */ }
+            foreach($iterator as $row) { /* Just force iterating */ }
             return $iterator;
         } else {
             return $this->getIterator();


### PR DESCRIPTION
Implemention currently in place seemed to eat a lot of memory. I refactored the code to not use [`iterator_to_array`](http://php.net/manual/en/function.iterator-to-array.php) and introduced a new IteratorWrapper class.

Currently the only difference is that `Sheet->rows()` and `Reader->sheets()` do not return an array but an iterator. But providing a callback for these methods work as before.